### PR TITLE
[Feat] 기업 상세페이지 QA 반영

### DIFF
--- a/src/features/home/ui/major-company-card/major-company-card.tsx
+++ b/src/features/home/ui/major-company-card/major-company-card.tsx
@@ -1,6 +1,12 @@
 import { assignInlineVars } from "@vanilla-extract/dynamic";
 import { useNavigate } from "react-router-dom";
 
+import {
+  getCompanyDetail,
+  getCompanySuggestions,
+} from "@/features/company-detail";
+import { queryClient } from "@/shared/api";
+import { companyQueryKey } from "@/shared/api/config/query-key";
 import { IconMove } from "@/shared/assets/icons";
 import { getScaleLabel } from "@/shared/config";
 import { Tag } from "@/shared/ui/tag/tag";
@@ -28,7 +34,20 @@ const MajorCompanyCard = ({
 }: MajorCompanyCardProps) => {
   const navigate = useNavigate();
 
+  const prefetchCompany = () => {
+    void queryClient.prefetchQuery({
+      queryKey: companyQueryKey.detail(id),
+      queryFn: () => getCompanyDetail(id),
+    });
+    void queryClient.prefetchQuery({
+      queryKey: companyQueryKey.suggestion(id),
+      queryFn: () => getCompanySuggestions(id),
+    });
+  };
+
   const handleClick = () => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    prefetchCompany();
     navigate(`/company/${id}`);
   };
 
@@ -36,7 +55,10 @@ const MajorCompanyCard = ({
     <button
       type="button"
       onClick={handleClick}
-      aria-label="기업 상세로 이동"
+      onMouseEnter={prefetchCompany}
+      onFocus={prefetchCompany}
+      onTouchStart={prefetchCompany}
+      aria-label="旮办梾 ?侅劯搿??措彊"
       className={styles.card({ type })}
       style={assignInlineVars({ [styles.bgImageUrl]: `url(${imgUrl})` })}
     >

--- a/src/pages/company-detail/company-detail-page.css.ts
+++ b/src/pages/company-detail/company-detail-page.css.ts
@@ -15,3 +15,10 @@ export const container = style({
   margin: "0 auto",
   padding: "0 2rem 0",
 });
+
+export const skeletonWrapper = style({
+  width: "100%",
+  height: "600px",
+  backgroundColor: themeVars.color.gray100,
+  borderRadius: "16px",
+});

--- a/src/pages/company-detail/company-detail-page.tsx
+++ b/src/pages/company-detail/company-detail-page.tsx
@@ -65,7 +65,9 @@ const CompanyDetailPage = () => {
       <div className={styles.container}>
         {companyData ? (
           <CompanyDetailSection companyData={companyData} />
-        ) : null}
+        ) : (
+          <div className={styles.skeletonWrapper} />
+        )}
       </div>
 
       <CompanyRecommendationSection

--- a/src/widgets/company-card/company-analyze-button.tsx
+++ b/src/widgets/company-card/company-analyze-button.tsx
@@ -1,5 +1,11 @@
 import { useNavigate } from "react-router-dom";
 
+import {
+  getCompanyDetail,
+  getCompanySuggestions,
+} from "@/features/company-detail";
+import { queryClient } from "@/shared/api";
+import { companyQueryKey } from "@/shared/api/config/query-key";
 import { IconCompany } from "@/shared/assets/icons";
 
 import * as styles from "./company-analyze-button.css";
@@ -11,12 +17,32 @@ interface CompanyAnalyzeButtonProps {
 const CompanyAnalyzeButton = ({ companyId }: CompanyAnalyzeButtonProps) => {
   const navigate = useNavigate();
 
+  const prefetchCompany = () => {
+    void queryClient.prefetchQuery({
+      queryKey: companyQueryKey.detail(companyId),
+      queryFn: () => getCompanyDetail(companyId),
+    });
+    void queryClient.prefetchQuery({
+      queryKey: companyQueryKey.suggestion(companyId),
+      queryFn: () => getCompanySuggestions(companyId),
+    });
+  };
+
   const handleClick = () => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    prefetchCompany();
     navigate(`/company/${companyId}`);
   };
 
   return (
-    <button type="button" className={styles.button} onClick={handleClick}>
+    <button
+      type="button"
+      className={styles.button}
+      onClick={handleClick}
+      onMouseEnter={prefetchCompany}
+      onFocus={prefetchCompany}
+      onTouchStart={prefetchCompany}
+    >
       <IconCompany className={styles.icon} />
       <span>기업 분석 보기</span>
     </button>


### PR DESCRIPTION
## ✏️ Summary
<!-- 관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->
- close #136 


## 📑 Tasks
<!-- 해당 PR에 수행한 작업을 작성해주세요. -->

### 문제

- 기업 상세 페이지에서 처음 진입한 기업(React Query 캐시 없음) 은 상세 데이터가 로딩되는 동안 상단 영역이 비어 보이면서 레이아웃이 순간적으로 당겨졌습니다.........

그 결과 하단 추천 섹션의 배경 이미지가 페인팅/재배치되며 깜빡이는 현상이 발생했습니다.

하지만 !! 이미 방문했던 기업은 같은 queryKey에 대한 데이터가 캐시에 남아 있어서 초기 렌더가 상대적으로 안정적이었습니다.....


### 해결

#### 1
- 초기 로딩 시 콘텐츠 높이가 확보되지 않아 예상치 못한 레이아웃 이동(레이아웃 시프트) 이 발생했다고 생각되어
  - 상세 데이터 로딩 중에도 레이아웃이 유지되도록, CompanyDetailSection 대신 고정 높이의 스켈레톤 플레이스홀더를 렌더링하도록 변경했습니다.
  - skeletonWrapper 스타일을 추가하고, 상세 데이터가 없을 때 아래 플레이스홀더를 렌더링하도록 하였습니다.

#### 2

- 기업 상세 페이지 진입 시 초기 로딩 지연을 줄이기 위해, 기업 상세/추천 데이터 쿼리를 queryClient.prefetchQuery로 사전 로딩하도록 추가했습니다.

- CompanyAnalyzeButton, MajorCompanyCard에서 hover/focus/touchStart 시점에 prefetch를 수행해, 사용자가 상세 페이지로 이동하기 전에 캐시가 채워지도록 개선했습니다아

## 👀 To Reviewer
<!-- 리뷰어에게 요청하는 내용을 작성해주세요. -->
- 

## 📸 Screenshot
<!-- 작업한 내용에 대한 스크린샷을 첨부해주세요. -->

## 🔔 ETC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회사 페이지 네비게이션 시 데이터 미리 로딩으로 더 빠른 페이지 전환 환경 제공
  * 사용자 상호작용(마우스 호버, 포커스, 터치)에 반응하는 스마트 프리페칭 기능 추가

* **개선사항**
  * 회사 상세 페이지 로딩 중 스켈레톤 로더 표시로 개선된 사용자 경험 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->