### PR TITLE
[Refactor] Observer pattern을 통한 전역 모달 관리

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@vanilla-extract/recipes": "^0.5.7",
     "@vanilla-extract/vite-plugin": "^5.1.4",
     "axios": "^1.13.2",
+    "es-hangul": "^2.3.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "framer-motion": "^12.27.1",
     "react": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       axios:
         specifier: ^1.13.2
         version: 1.13.2
+      es-hangul:
+        specifier: ^2.3.8
+        version: 2.3.8
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
@@ -1928,6 +1931,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-hangul@2.3.8:
+    resolution: {integrity: sha512-VrJuqYBC7W04aKYjCnswomuJNXQRc0q33SG1IltVrRofi2YEE6FwVDPlsEJIdKbHwsOpbBL/mk9sUaBxVpbd+w==}
 
   es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
@@ -5768,6 +5774,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-hangul@2.3.8: {}
 
   es-iterator-helpers@1.2.2:
     dependencies:

--- a/src/app/providers/index.tsx
+++ b/src/app/providers/index.tsx
@@ -1,4 +1,3 @@
-import { ModalProvider } from "./modal-provider";
 import { QueryProvider } from "./query-provider";
 import ThemeProvider from "./theme-provider";
 
@@ -17,7 +16,6 @@ export const AppProviders = ({
     <QueryProvider>
       <ThemeProvider theme={theme} className={className}>
         {children}
-        <ModalProvider />
       </ThemeProvider>
     </QueryProvider>
   );

--- a/src/app/providers/index.tsx
+++ b/src/app/providers/index.tsx
@@ -1,3 +1,4 @@
+import { ModalProvider } from "./modal-provider";
 import { QueryProvider } from "./query-provider";
 import ThemeProvider from "./theme-provider";
 
@@ -16,6 +17,7 @@ export const AppProviders = ({
     <QueryProvider>
       <ThemeProvider theme={theme} className={className}>
         {children}
+        <ModalProvider />
       </ThemeProvider>
     </QueryProvider>
   );

--- a/src/app/providers/modal-provider.tsx
+++ b/src/app/providers/modal-provider.tsx
@@ -16,8 +16,8 @@ export const ModalProvider = () => {
   const [modals, setModals] = useState<ModalItem[]>([]);
 
   useEffect(() => {
-    modalStore.subscribe(setModals);
-    return () => modalStore.unsubscribe();
+    const unsubscribe = modalStore.subscribe(setModals);
+    return unsubscribe;
   }, []);
 
   useEffect(() => {

--- a/src/app/providers/modal-provider.tsx
+++ b/src/app/providers/modal-provider.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+import { modalStore } from "@/shared/model/store";
+
+import { Modal } from "../../shared/ui/modal/modal";
+
+interface ModalItem {
+  id: string;
+  content: ReactNode;
+  autoPlay?: number;
+}
+
+export const ModalProvider = () => {
+  const [modals, setModals] = useState<ModalItem[]>([]);
+
+  useEffect(() => {
+    modalStore.subscribe(setModals);
+    return () => modalStore.unsubscribe();
+  }, []);
+
+  return (
+    <>
+      {modals.map((modal) => {
+        return (
+          <Modal
+            key={modal.id}
+            isOpen={true}
+            autoPlay={modal.autoPlay}
+            onClose={() => modalStore.close(modal.id)}
+          >
+            {modal.content}
+          </Modal>
+        );
+      })}
+    </>
+  );
+};

--- a/src/app/providers/modal-provider.tsx
+++ b/src/app/providers/modal-provider.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
+import { useLocation } from "react-router-dom";
 
 import { modalStore } from "@/shared/model/store";
 
@@ -11,12 +12,17 @@ interface ModalItem {
 }
 
 export const ModalProvider = () => {
+  const { pathname } = useLocation();
   const [modals, setModals] = useState<ModalItem[]>([]);
 
   useEffect(() => {
     modalStore.subscribe(setModals);
     return () => modalStore.unsubscribe();
   }, []);
+
+  useEffect(() => {
+    modalStore.reset();
+  }, [pathname]);
 
   return (
     <>

--- a/src/app/providers/modal-provider.tsx
+++ b/src/app/providers/modal-provider.tsx
@@ -12,7 +12,7 @@ interface ModalItem {
 }
 
 export const ModalProvider = () => {
-  const { pathname } = useLocation();
+  const location = useLocation();
   const [modals, setModals] = useState<ModalItem[]>([]);
 
   useEffect(() => {
@@ -22,7 +22,7 @@ export const ModalProvider = () => {
 
   useEffect(() => {
     modalStore.reset();
-  }, [pathname]);
+  }, [location.key]);
 
   return (
     <>

--- a/src/app/routes/root-layout.tsx
+++ b/src/app/routes/root-layout.tsx
@@ -2,11 +2,13 @@ import { Outlet } from "react-router-dom";
 
 import { Header } from "@widgets/index";
 
+import { ModalProvider } from "../providers/modal-provider";
 import { StoreResetListener } from "../providers/store-reset-listener";
 
 export const RootLayout = () => {
   return (
     <>
+      <ModalProvider />
       <StoreResetListener />
       <Header />
       <main>

--- a/src/features/experience-detail/model/use-leave-confirm.tsx
+++ b/src/features/experience-detail/model/use-leave-confirm.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useCallback, useRef } from "react";
+import { useEffect, useCallback } from "react";
 import { useBlocker } from "react-router-dom";
 
-import { useModal } from "@/shared/ui/modal/use-modal";
+import { modalStore } from "@/shared/model/store";
+import { ModalBasic } from "@/shared/ui";
 
 import {
   initialDraft,
@@ -24,10 +25,9 @@ const isDraftDirty = (draft: ExperienceUpsertBody): boolean => {
 };
 
 export const useLeaveConfirm = () => {
+  const LEAVE_MODAL_ID = "leave-confirm-modal";
   const mode = useExperienceDetailStore((s) => s.mode);
   const draft = useExperienceDetailStore((s) => s.draft);
-
-  const { isOpen, openModal, closeModal } = useModal();
 
   const shouldBlock =
     (mode === "create" || mode === "edit") && isDraftDirty(draft);
@@ -46,17 +46,36 @@ export const useLeaveConfirm = () => {
     return shouldBlockNow && !isSubmitting && !isTransitioning;
   });
 
-  const prevBlockerStateRef = useRef(blocker.state);
+  const confirmLeave = useCallback(() => {
+    if (blocker.state === "blocked") {
+      blocker.proceed();
+    }
+  }, [blocker]);
+
+  const cancelLeave = useCallback(() => {
+    if (blocker.state === "blocked") {
+      blocker.reset();
+    }
+    modalStore.close(LEAVE_MODAL_ID);
+  }, [blocker]);
 
   useEffect(() => {
-    const wasBlocked = prevBlockerStateRef.current === "blocked";
-    const nowBlocked = blocker.state === "blocked";
-    prevBlockerStateRef.current = blocker.state;
-
-    if (nowBlocked && !wasBlocked && !isOpen) {
-      openModal();
+    if (blocker.state === "blocked") {
+      modalStore.open(
+        <ModalBasic
+          title={`작성중인 내용이 있습니다.\n정말 나가시겠습니까?`}
+          subTitle="저장하지 않으면 내용이 사라져요."
+          closeText="이어서 작성"
+          confirmText="나가기"
+          onClose={cancelLeave}
+          onConfirm={confirmLeave}
+        />,
+        0,
+        undefined,
+        LEAVE_MODAL_ID
+      );
     }
-  }, [blocker.state, isOpen, openModal]);
+  }, [blocker.state, cancelLeave, confirmLeave]);
 
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
@@ -70,23 +89,5 @@ export const useLeaveConfirm = () => {
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [shouldBlock]);
 
-  const confirmLeave = useCallback(() => {
-    if (blocker.state === "blocked") {
-      blocker.proceed();
-    }
-    closeModal();
-  }, [blocker, closeModal]);
-
-  const cancelLeave = useCallback(() => {
-    if (blocker.state === "blocked") {
-      blocker.reset();
-    }
-    closeModal();
-  }, [blocker, closeModal]);
-
-  return {
-    isOpen,
-    confirmLeave,
-    cancelLeave,
-  };
+  return {};
 };

--- a/src/features/experience-detail/model/use-leave-confirm.tsx
+++ b/src/features/experience-detail/model/use-leave-confirm.tsx
@@ -24,8 +24,9 @@ const isDraftDirty = (draft: ExperienceUpsertBody): boolean => {
   );
 };
 
+const LEAVE_MODAL_ID = "leave-confirm-modal";
+
 export const useLeaveConfirm = () => {
-  const LEAVE_MODAL_ID = "leave-confirm-modal";
   const mode = useExperienceDetailStore((s) => s.mode);
   const draft = useExperienceDetailStore((s) => s.draft);
 
@@ -50,6 +51,7 @@ export const useLeaveConfirm = () => {
     if (blocker.state === "blocked") {
       blocker.proceed();
     }
+    modalStore.close(LEAVE_MODAL_ID);
   }, [blocker]);
 
   const cancelLeave = useCallback(() => {

--- a/src/features/experience-detail/ui/experience-viewer/experience-viewer.tsx
+++ b/src/features/experience-detail/ui/experience-viewer/experience-viewer.tsx
@@ -1,8 +1,8 @@
 import { EXPERIENCE_TYPE } from "@/shared/config/experience";
 import { parseYMD } from "@/shared/lib/format-date";
+import { modalStore } from "@/shared/model/store";
 import { ModalBasic, Tooltip } from "@/shared/ui";
 import { Button } from "@/shared/ui/button/button";
-import { useModal } from "@/shared/ui/modal/use-modal";
 import { Tag } from "@/shared/ui/tag/tag";
 import { Textfield } from "@/shared/ui/textfield/textfield";
 import { HELP_TOOLTIP_CONTENT } from "@/shared/ui/tooltip/tooltip.content";
@@ -24,9 +24,6 @@ const ExperienceViewer = () => {
   const { showEditDelete, onClickEdit, onClickDelete, onToggleDefault } =
     useExperienceHeaderActions();
 
-  const { isOpen: isDeleteModalOpen, handleModal: toggleDeleteModal } =
-    useModal();
-
   const startDate = current?.startAt ? parseYMD(current.startAt) : null;
   const endDate = current?.endAt ? parseYMD(current.endAt) : null;
 
@@ -42,6 +39,22 @@ const ExperienceViewer = () => {
 
   const typeLabel = current.type ? EXPERIENCE_TYPE[current.type] : "미지정";
 
+  const handleOpenDeleteModal = () => {
+    modalStore.open(
+      <ModalBasic
+        title="이 경험을 삭제하시겠습니까?"
+        subTitle="작성한 내용은 즉시 제거되며, 복구할 수 없습니다."
+        closeText="취소"
+        confirmText="삭제"
+        onClose={() => modalStore.reset()} // 취소 시 닫기
+        onConfirm={() => {
+          onClickDelete(); // 실제 삭제 동작
+          modalStore.reset(); // 모달 닫기
+        }}
+      />
+    );
+  };
+
   return (
     <main className={s.page}>
       <StickyHeader
@@ -53,7 +66,7 @@ const ExperienceViewer = () => {
               <Button
                 variant="secondary"
                 size="small"
-                onClick={toggleDeleteModal}
+                onClick={handleOpenDeleteModal}
               >
                 삭제하기
               </Button>
@@ -130,19 +143,6 @@ const ExperienceViewer = () => {
           </div>
         </div>
       </section>
-
-      <ModalBasic
-        title="이 경험을 삭제하시겠습니까?"
-        subTitle="작성한 내용은 즉시 제거되며, 복구할 수 없습니다."
-        closeText="취소"
-        confirmText="삭제"
-        isOpen={isDeleteModalOpen}
-        onClose={toggleDeleteModal}
-        onConfirm={() => {
-          toggleDeleteModal();
-          onClickDelete();
-        }}
-      />
     </main>
   );
 };

--- a/src/features/experience-matching/ui/select-company/select-company.tsx
+++ b/src/features/experience-matching/ui/select-company/select-company.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ROUTES } from "@/app/routes/paths";
-import { Button, Modal, useModal } from "@/shared/ui";
+import { modalStore } from "@/shared/model/store";
+import { Button, Modal } from "@/shared/ui";
 import {
   useGetExperience,
   useGetCompanyList,
@@ -19,53 +20,61 @@ export const SelectCompany = ({ onClick }: { onClick: () => void }) => {
   const navigate = useNavigate();
   const { data } = useGetExperience(); // 경험 조회 API
 
-  /** Report 전역 상태  */
+  // AI-Report 입력 단계 저장을 위한 전역 상태
   const setCompany = useReportStore((state) => state.setCompany);
   const company = useReportStore((state) => state.company);
 
-  /** 모달 상태 관리 */
-  const { autoPlay, isOpen, handleModal } = useModal(3000); // 몇 초 뒤 닫히게 할 건지 정의
-  const alertModal = useModal(); // 경험 등록 여부 확인 모달
-
-  /** 입력 데이터 상태 관리 */
+  // 기업 입력 데이터 상태 관리
   const [inputValue, setInputValue] = useState(""); // 실시간 입력 상태
   const [searchKeyword, setSearchKeyword] = useState(""); // 디바운스된 키워드 상태
   const [selectedCompany, setSelectedCompany] = useState<Company | null>(
     company
   );
-
-  // 경험 등록 여부 확인 모달 오픈
-  useEffect(() => {
-    if (data?.totalElements === 0) {
-      if (!alertModal.isOpen) {
-        alertModal.openModal();
-      }
-    }
-  }, [data, alertModal]);
-
-  // useEffect(() => {
-  //   if (company?.id) {
-  //     const temp={
-  //       id:company.id,
-  //       name:company.name
-  //     }
-  //     setSelectedCompany(temp);
-  //   }
-  // }, [company]);
-
   const { data: searchResults = [] } = useGetCompanyList(searchKeyword); // 기업 검색 API
 
-  // 모달 닫힘 여부 확인 후 페이지 이동
-  const prevIsOpen = useRef(isOpen);
+  // 경험 등록 여부 확인 모달
   useEffect(() => {
-    if (prevIsOpen.current === true && isOpen === false) {
-      if (selectedCompany) {
-        setCompany(selectedCompany); // 선택된 기업 데이터 저장
+    if (data?.totalElements !== 0) {
+      modalStore.open(
+        <>
+          <Modal.Content>
+            <Modal.Title>아직 등록된 경험이 없습니다</Modal.Title>
+            <Modal.SubTitle>지금 바로 경험을 등록하러 가볼까요?</Modal.SubTitle>
+          </Modal.Content>
+          <Modal.Buttons>
+            <Button variant="secondary" onClick={() => navigate(ROUTES.HOME)}>
+              나가기
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => navigate(ROUTES.EXPERIENCE_CREATE)}
+            >
+              이동하기
+            </Button>
+          </Modal.Buttons>
+        </>
+      );
+    }
+  }, [data, navigate]);
+
+  const handleSearch = () => {
+    if (!selectedCompany) return;
+    // 기업 선택 후, 대기하는 모달
+    modalStore.open(
+      <>
+        <Modal.Content type="auto">
+          <Modal.Title>{selectedCompany.name}을 선택하셨습니다</Modal.Title>
+          <Modal.SubTitle>기업분석 내용을 불러오는 중입니다.</Modal.SubTitle>
+        </Modal.Content>
+        <Modal.Image />
+      </>,
+      3000,
+      () => {
+        setCompany(selectedCompany);
         onClick();
       }
-    }
-    prevIsOpen.current = isOpen;
-  }, [isOpen, selectedCompany, onClick, setCompany]);
+    );
+  };
 
   return (
     <div className={styles.layout}>
@@ -77,39 +86,8 @@ export const SelectCompany = ({ onClick }: { onClick: () => void }) => {
         onDebounceChange={setSearchKeyword}
         selectedItem={selectedCompany}
         onSelect={setSelectedCompany}
-        onSearch={handleModal}
+        onSearch={handleSearch}
       />
-      {/** 경험 등록 여부 확인 모달 */}
-      <Modal isOpen={alertModal.isOpen} onClose={alertModal.closeModal}>
-        <Modal.Content>
-          <Modal.Title>아직 등록된 경험이 없습니다</Modal.Title>
-          <Modal.SubTitle>지금 바로 경험을 등록하러 가볼까요?</Modal.SubTitle>
-        </Modal.Content>
-        <Modal.Buttons>
-          <Button
-            variant="secondary"
-            size="large"
-            onClick={() => navigate(ROUTES.HOME)}
-          >
-            나가기
-          </Button>
-          <Button
-            variant="primary"
-            size="large"
-            onClick={() => navigate(ROUTES.EXPERIENCE_CREATE)}
-          >
-            이동하기
-          </Button>
-        </Modal.Buttons>
-      </Modal>
-      {/** 기업 선택 후, 대기 모달 */}
-      <Modal autoPlay={autoPlay} isOpen={isOpen} onClose={handleModal}>
-        <Modal.Content type="auto">
-          <Modal.Title>{selectedCompany?.name}을 선택하셨습니다</Modal.Title>
-          <Modal.SubTitle>기업분석 내용을 불러오는 중입니다.</Modal.SubTitle>
-        </Modal.Content>
-        <Modal.Image />
-      </Modal>
     </div>
   );
 };

--- a/src/features/experience-matching/ui/select-company/select-company.tsx
+++ b/src/features/experience-matching/ui/select-company/select-company.tsx
@@ -34,7 +34,7 @@ export const SelectCompany = ({ onClick }: { onClick: () => void }) => {
 
   // 경험 등록 여부 확인 모달
   useEffect(() => {
-    if (data?.totalElements !== 0) {
+    if (data?.totalElements === 0) {
       modalStore.open(
         <>
           <Modal.Content>

--- a/src/features/experience-matching/ui/select-company/select-company.tsx
+++ b/src/features/experience-matching/ui/select-company/select-company.tsx
@@ -1,3 +1,4 @@
+import { josa } from "es-hangul";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -15,7 +16,6 @@ import { MatchingAutoComplete } from "../matching-auto-complete/matching-auto-co
 import * as styles from "./select-company.css";
 
 import type { Company } from "../../type";
-
 export const SelectCompany = ({ onClick }: { onClick: () => void }) => {
   const navigate = useNavigate();
   const { data } = useGetExperience(); // 경험 조회 API
@@ -63,7 +63,9 @@ export const SelectCompany = ({ onClick }: { onClick: () => void }) => {
     modalStore.open(
       <>
         <Modal.Content type="auto">
-          <Modal.Title>{selectedCompany.name}을 선택하셨습니다</Modal.Title>
+          <Modal.Title>
+            {josa(selectedCompany.name, "을/를")} 선택하셨습니다
+          </Modal.Title>
           <Modal.SubTitle>기업분석 내용을 불러오는 중입니다.</Modal.SubTitle>
         </Modal.Content>
         <Modal.Image />

--- a/src/features/experience-matching/ui/select-company/select-company.tsx
+++ b/src/features/experience-matching/ui/select-company/select-company.tsx
@@ -52,7 +52,10 @@ export const SelectCompany = ({ onClick }: { onClick: () => void }) => {
               이동하기
             </Button>
           </Modal.Buttons>
-        </>
+        </>,
+        undefined,
+        undefined,
+        "NO-EXPERIENCE"
       );
     }
   }, [data, navigate]);

--- a/src/pages/experience-detail/experience-detail-page.tsx
+++ b/src/pages/experience-detail/experience-detail-page.tsx
@@ -11,7 +11,6 @@ import {
   useGetExperienceDetail,
   hydrateExperienceFromApi,
 } from "@/features/experience-detail";
-import { ModalBasic } from "@/shared/ui/modal/modal-basic";
 
 import type { ExperienceMode } from "@/features/experience-detail";
 
@@ -22,7 +21,7 @@ interface ExperiencePageProps {
 const ExperienceDetailPage = ({ mode }: ExperiencePageProps) => {
   const { id: experienceId } = useParams<{ id: string }>();
   const currentMode = useExperienceMode();
-  const { isOpen, confirmLeave, cancelLeave } = useLeaveConfirm();
+  useLeaveConfirm();
   const initializedExperienceIdRef = useRef<string | null>(null);
 
   const parsedExperienceId = experienceId ? Number(experienceId) : NaN;
@@ -69,15 +68,6 @@ const ExperienceDetailPage = ({ mode }: ExperiencePageProps) => {
     <>
       {content}
       <ExperienceAlertRenderer />
-      <ModalBasic
-        isOpen={isOpen}
-        onClose={cancelLeave}
-        onConfirm={confirmLeave}
-        title={`작성중인 내용이 있습니다.\n정말 나가시겠습니까?`}
-        subTitle="저장하지 않으면 내용이 사라져요."
-        closeText="이어서 작성"
-        confirmText="나가기"
-      />
     </>
   );
 };

--- a/src/shared/model/store/index.ts
+++ b/src/shared/model/store/index.ts
@@ -1,1 +1,2 @@
 export { useAuthStore } from "./auth.store";
+export { modalStore } from "./modal.store";

--- a/src/shared/model/store/modal.store.ts
+++ b/src/shared/model/store/modal.store.ts
@@ -32,10 +32,21 @@ class ModalStore {
     onClose?: () => void,
     id: string = new Date().toString()
   ) {
-    const new_modal = { id: id, content: content, autoPlay, onClose };
-    this._modalList = [...this._modalList, new_modal];
+    const newModal = { id, content, autoPlay, onClose }; // 새로 열고자 하는 모달
+
+    // 기존 타이머(중복)가 있다면 제거
+    if (this._timers.has(id)) {
+      clearTimeout(this._timers.get(id));
+      this._timers.delete(id);
+    }
+
+    // 리스트에서 기존 모달을 제거하고, 최상단에 새 모달 삽입
+    const filteredList = this._modalList.filter((m) => m.id !== id);
+    this._modalList = [...filteredList, newModal];
+
     this.notify();
 
+    // 타이머 재설정
     if (autoPlay && autoPlay > 0) {
       const timer = setTimeout(() => {
         this.close(id);

--- a/src/shared/model/store/modal.store.ts
+++ b/src/shared/model/store/modal.store.ts
@@ -9,15 +9,21 @@ interface ModalItem {
 
 class ModalStore {
   private _modalList: ModalItem[] = []; // 모달 리스트 관리
-  private _listner: ((list: ModalItem[]) => void) | null = null;
+  private _listeners = new Set<(list: ModalItem[]) => void>();
   private _timers = new Map<string, NodeJS.Timeout>(); // 타이머 관리
 
-  subscribe(callback: (list: ModalItem[]) => void) {
-    this._listner = callback; // 모달 리스트 상태 업데이트 함수 등록
+  private notify() {
+    this._listeners.forEach((listener) => {
+      listener(this._modalList);
+    });
   }
 
-  unsubscribe() {
-    this._listner = null;
+  subscribe(callback: (list: ModalItem[]) => void) {
+    this._listeners.add(callback); // 모달 리스트 상태 업데이트 함수 등록
+
+    return () => {
+      this._listeners.delete(callback);
+    };
   }
 
   open(
@@ -28,7 +34,7 @@ class ModalStore {
   ) {
     const new_modal = { id: id, content: content, autoPlay, onClose };
     this._modalList = [...this._modalList, new_modal];
-    this._listner?.(this._modalList);
+    this.notify();
 
     if (autoPlay && autoPlay > 0) {
       const timer = setTimeout(() => {
@@ -49,7 +55,7 @@ class ModalStore {
     const target = this._modalList.find((m) => m.id === id);
 
     this._modalList = this._modalList.filter((modal) => modal.id !== id);
-    this._listner?.(this._modalList);
+    this.notify();
 
     if (target?.onClose) target.onClose();
   }
@@ -60,7 +66,7 @@ class ModalStore {
     this._timers.clear(); // 메모리 참조 제거
 
     this._modalList = [];
-    this._listner?.(this._modalList);
+    this.notify();
   }
 }
 

--- a/src/shared/model/store/modal.store.ts
+++ b/src/shared/model/store/modal.store.ts
@@ -10,6 +10,7 @@ type ModalItem = {
 class ModalStore {
   private _modalList: ModalItem[] = []; // 모달 리스트 관리
   private _listner: ((list: ModalItem[]) => void) | null = null;
+  private _timers = new Map<string, NodeJS.Timeout>(); // 타이머 관리
 
   subscribe(callback: (list: ModalItem[]) => void) {
     this._listner = callback; // 모달 리스트 상태 업데이트 함수 등록
@@ -30,17 +31,27 @@ class ModalStore {
     this._listner?.(this._modalList);
 
     if (autoPlay && autoPlay > 0) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         this.close(id);
       }, autoPlay);
+
+      this._timers.set(id, timer);
     }
   }
 
   close(id: string) {
+    // 수동으로 닫았을 때(ex. pathname 이동) 예약된 setTimeout이 실행되지 않도록 제거
+    if (this._timers.has(id)) {
+      clearTimeout(this._timers.get(id));
+      this._timers.delete(id);
+    }
+
     const target = this._modalList.find((m) => m.id === id);
-    if (target?.onClose) target.onClose();
+
     this._modalList = this._modalList.filter((modal) => modal.id !== id);
     this._listner?.(this._modalList);
+
+    if (target?.onClose) target.onClose();
   }
 
   reset() {

--- a/src/shared/model/store/modal.store.ts
+++ b/src/shared/model/store/modal.store.ts
@@ -1,11 +1,11 @@
 import type { ReactNode } from "react";
 
-type ModalItem = {
+interface ModalItem {
   id: string;
   content: ReactNode;
   onClose?: () => void;
   autoPlay?: number;
-};
+}
 
 class ModalStore {
   private _modalList: ModalItem[] = []; // 모달 리스트 관리
@@ -55,6 +55,10 @@ class ModalStore {
   }
 
   reset() {
+    // 예약된 타이머 제거
+    this._timers.forEach(clearTimeout);
+    this._timers.clear(); // 메모리 참조 제거
+
     this._modalList = [];
     this._listner?.(this._modalList);
   }

--- a/src/shared/model/store/modal.store.ts
+++ b/src/shared/model/store/modal.store.ts
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+
+type ModalItem = {
+  id: string;
+  content: ReactNode;
+  onClose?: () => void;
+  autoPlay?: number;
+};
+
+class ModalStore {
+  private _modalList: ModalItem[] = []; // 모달 리스트 관리
+  private _listner: ((list: ModalItem[]) => void) | null = null;
+
+  subscribe(callback: (list: ModalItem[]) => void) {
+    this._listner = callback; // 모달 리스트 상태 업데이트 함수 등록
+  }
+
+  unsubscribe() {
+    this._listner = null;
+  }
+
+  open(
+    content: ReactNode,
+    autoPlay?: number,
+    onClose?: () => void,
+    id: string = new Date().toString()
+  ) {
+    const new_modal = { id: id, content: content, autoPlay, onClose };
+    this._modalList = [...this._modalList, new_modal];
+    this._listner?.(this._modalList);
+
+    if (autoPlay && autoPlay > 0) {
+      setTimeout(() => {
+        this.close(id);
+      }, autoPlay);
+    }
+  }
+
+  close(id: string) {
+    const target = this._modalList.find((m) => m.id === id);
+    if (target?.onClose) target.onClose();
+    this._modalList = this._modalList.filter((modal) => modal.id !== id);
+    this._listner?.(this._modalList);
+  }
+
+  reset() {
+    this._modalList = [];
+    this._listner?.(this._modalList);
+  }
+}
+
+export const modalStore = new ModalStore();

--- a/src/shared/ui/modal/modal-basic.tsx
+++ b/src/shared/ui/modal/modal-basic.tsx
@@ -3,7 +3,6 @@ import { Button } from "../button/button";
 import { Modal } from "./modal";
 
 interface ModalBasicProps {
-  isOpen: boolean; // 모달 오픈 여부
   onClose: () => void; // 모달 닫기 액션
   onConfirm: () => void; // 모달 작업 확인 액션
   title: string; // 모달 제목
@@ -17,7 +16,6 @@ interface ModalBasicProps {
  * - 많이 사용되는 모달 스타일을 정의한 모달 래퍼 함수입니다.
  */
 export const ModalBasic = ({
-  isOpen,
   onClose,
   onConfirm,
   title,
@@ -26,7 +24,7 @@ export const ModalBasic = ({
   confirmText = "이어서 작성하기",
 }: ModalBasicProps) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <>
       <Modal.XButton />
       <Modal.Content>
         <Modal.Title>{title}</Modal.Title>
@@ -40,6 +38,6 @@ export const ModalBasic = ({
           {confirmText}
         </Button>
       </Modal.Buttons>
-    </Modal>
+    </>
   );
 };

--- a/src/shared/ui/textfield/textfield.tsx
+++ b/src/shared/ui/textfield/textfield.tsx
@@ -14,7 +14,7 @@ export type TextfieldType =
   | "action";
 
 const TEXTFIELD_MAX_LENGTH: Record<TextfieldType, number> = {
-  jobDescription: 300,
+  jobDescription: 500,
   situation: 200,
   task: 200,
   result: 300,


### PR DESCRIPTION
## ✏️ Summary
<!-- 관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->
- close #153 
- **observer pattern**을 결합한 전역 모달 시스템을 구현하였습니다.

## 📑 Tasks
<!-- 해당 PR에 수행한 작업을 작성해주세요. -->
### ⁉️기존 구조에서 observer 패턴을 도입한 이유
기존의 구조는 비슷하지만 각각 다른 UI의 모달 컴포넌트을 쉽게 구성할 수 있도록 **컴파운트 패턴**을 활용하여 UI의 유연성을 높였습니다. 또한 모달이 `open`, `close` 상태를 기준으로 열리고 닫힐 수 있도록 `use-modal` 훅을 분리하여 상태를 관리하도록 했습니다. 

하지만 실제 **모달 컴포넌트를 코드에 사용하는 측면에 있어 두 가지 문제점**이 있다고 생각했습니다.

만약 어떤 컴포넌트(`select-company.tsx`)에서 사용하는 모달의 개수가 2가지 이상이 된다면, 각각의 모달의 상태를 위해  
각각 `use-modal`훅을 호출하여 각자의 `isOpen`를 관리하도록 해야 했습니다. 한 가지 모달만 사용할 때도 무조건 `use-modal`훅을 호출해야 한다는 사실도 DX 관점에서 좋지 않다는 생각이 들기도 했습니다.
```js
// (이전) 모달 상태 관리 
const { autoPlay, isOpen, handleModal } = useModal(3000); // 기업 선택 이후 3초 후 넘어가게 하는 모달
const alertModal = useModal(); // 경험 등록 여부 확인 모달
```

또한 JSX 코드에서 실제 컴포넌트 내용과는 약간 무관한, 동떨어져 있는 모달 코드를 JSX 코드에 함께 작성해야해 컴포넌트의 의미를 명확하게 하지 못하는 한계가 있다고 느껴졌습니다. 
```js
// 반환부에 실질적인 컴포넌트 코드과 모달 코드가 섞여 있어 가독성을 해쳐 의미를 파악하기 어려움
return (
  <div className={styles.layout}>
    <h1 className={styles.title}>어떤 기업을 분석할까요?</h1>
    <MatchingAutoComplete
      value={inputValue}
      onChange={setInputValue}
      results={searchResults}
      onDebounceChange={setSearchKeyword}
      selectedItem={selectedCompany}
      onSelect={setSelectedCompany}
      onSearch={handleModal}
      onSearch={handleSearch}
    />
    {/** 경험 등록 여부 확인 모달 */}
    <Modal isOpen={alertModal.isOpen} onClose={alertModal.closeModal}>
    </Modal>
    {/** 기업 선택 후, 대기 모달 */}
    <Modal autoPlay={autoPlay} isOpen={isOpen} onClose={handleModal}>
    </Modal>
  </div>
);
```

이러한 문제점을 해결하기 위해 `observer pattern`을 도입하기로 했습니다. 

**`observer pattern`을 도입한 이유는 다음과 같습니다.**
- 가장 큰 목적은 애플리케이션 전체에서 쓰이는 공통 UI인 모달의 렌더링 책임을 전역 `ModalContainer` 한 곳으로 위임하여, 개별 컴포넌트의 JSX 구조를 본연의 역할에 맞게 간결하게 유지하고 관심사를 분리하는 것입니다.
- `modalStore.open()`과 같은 단순한 명령형 함수 호출만으로 쉽게 모달을 제어할 수 있어 개발 생산성을  높일 수 있습니다.
- 특히, 전역 상태 라이브러리의 도입을 최소화하려는 팀의 지향점에 맞춰, Context API의 리렌더링 문제나 외부 라이브러리 의존 없이 순수 자바스크립트 클래스만으로 가볍게 전역 상태를 관리할 수 있다는 점을 중요하게 생각했습니다. 


### observer class 구현 (`modal.store.ts`)
**modalList** 배열을 통해 모달 상태를 관리하는 순수 JS 클래스를 선언하고, 싱글톤 인스턴스로 export 하였습니다.
```js
import type { ReactNode } from "react";

class ModalStore {
  private _modalList: ModalItem[] = []; // 모달 리스트 관리
  private _listeners = new Set<(list: ModalItem[]) => void>();
  private _timers = new Map<string, NodeJS.Timeout>(); // 타이머 관리

  private notify() {
    this._listeners.forEach((listener) => {
      listener(this._modalList);
    });
  }

  subscribe(callback: (list: ModalItem[]) => void) {
    this._listeners.add(callback); // 모달 리스트 상태 업데이트 함수 등록

    return () => {
      this._listeners.delete(callback);
    };
  }

  open(
    content: ReactNode,
    autoPlay?: number,
    onClose?: () => void,
    id: string = new Date().toString()
  ) {
      // 모달을 open하는 메서드
  }

  close(id: string) {
     // 특정 모달만 리셋하는 메서드
  }

  reset() {
      // 모든 모달을 리셋하는 메서드
  }
}

export const modalStore = new ModalStore();
```
[ **+ 추가 수정사항** ]
현재 구현에서는 `ModalProvider` 하나만 `subscribe`하고 있기 때문에 실제 동작에는 문제가 없습니다. 다만 `ModalStore`의 `subscribe()`가 단일 콜백만 보관하는 구조라, 이후 다른 컴포넌트에서 동일한 store를 구독하게 될 경우 기존 subscriber가 덮어써지거나 `unsubscribe()` 호출 시 의도하지 않게 다른 subscriber까지 해제될 가능성이 있습니다.

Publisher–Subscriber 관계를 **1:1이 아닌 1:N 구조로 명확하게 관리하는 것이 더 안전하기 때문에** 이를 위해 내부 listener를 하나의 콜백이 아닌 컬렉션으로 관리하고, `subscribe()`가 해당 subscriber만 해제할 수 있는 cleanup 함수를 반환하는 형태로 수정하였습니다. 

### 모달을 보여줄 Provider 정의 (`modal-provider.ts`)
**modalStore**를 실질적으로 구독하여 전역 상태가 변경될 때마다 **_modalList**에 등록된 모달들을 렌더링하는 최상단 렌더링 컨테이너입니다. 특정 컴포넌트에서 `modalStore.open()` 명령을 보내면, 상태가 변경되었음으로 판단하고 해당 모달을 보여주기 위해 렌더링되는 것입니다.
```js
export const ModalProvider = () => {
  const { pathname } = useLocation();
  const [modals, setModals] = useState<ModalItem[]>([]);

  useEffect(() => {
    modalStore.subscribe(setModals);            // modal-provider가 modal-store에 대한 상태를 구독합니다.
    return () => modalStore.unsubscribe();
  }, []);

  useEffect(() => {
    modalStore.reset();
  }, [pathname]);

  return (
     // 구독한 store의 상태가 변경되면 리렌더링을 진행
    <>
      {modals.map((modal) => {
        return (
          <Modal
            key={modal.id}
            isOpen={true}
            autoPlay={modal.autoPlay}
            onClose={() => modalStore.close(modal.id)}
          >
            {modal.content}
          </Modal>
        );
      })}
    </>
  );
};

```

컴포넌트는 오직 모달을 열어라라는 명령(`modalStore.open`)만 내리기 때문에, 실제 UI 렌더링 책임은 전역 컨테이너로 넘어갔으며, 컴포넌트 내 JSX는 자신의 컴포넌트 내용 자체에만 집중할 수 있습니다.

```tsx
// 경험 등록 여부 확인 모달 (모달 관련 코드가 JSX코드 밖으로 이동)
useEffect(() => {
  if (data?.totalElements === 0) {
    modalStore.open(
      <>
        <Modal.Content>
          <Modal.Title>아직 등록된 경험이 없습니다</Modal.Title>
          <Modal.SubTitle>지금 바로 경험을 등록하러 가볼까요?</Modal.SubTitle>
        </Modal.Content>
        <Modal.Buttons>
          <Button variant="secondary" onClick={() => navigate(ROUTES.HOME)}>
            나가기
          </Button>
          <Button
            variant="primary"
            onClick={() => navigate(ROUTES.EXPERIENCE_CREATE)}
          >
            이동하기
          </Button>
        </Modal.Buttons>
      </>
    );
  }
}, [data, navigate]);
```


**[추가적인 트러블 슈팅]**
전역으로 모달을 분리하면서, 모달이 열린 상태에서 뒤로 가기를 누르거나 페이지를 이동할 경우 모달 자체의 상태가 변화한 것이 아니기 때문에 `onClose` 이벤트가 발생하지 않아 이동 페이지에서도 모달이 계속 떠 있는 문제가 있었습니다.

```js
export const ModalProvider = () => {
  const { pathname } = useLocation();
  const [modals, setModals] = useState<ModalItem[]>([]);

  useEffect(() => {
    const unsubscribe = modalStore.subscribe(setModals);
    return unsubscribe;
  }, []);

  // pathname이 변경됨을 감지해 모달이 초기화되도록 함.
  useEffect(() => {
    modalStore.reset();
  }, [pathname]);
```

이를 위해 `useLocation`을 통해 pathname의 변경을 감지하고, 라우트가 바뀔 때  `modalStore.reset()`을 호출하여 모달이 닫힐 수있도록 ModalProvider에 로직을 추가했습니다.

## 👀 To Reviewer
<!-- 리뷰어에게 요청하는 내용을 작성해주세요. -->
- 전역적으로 모달상태를 관리함에 따라 모달의 상태를 관리했던 `use-modal`은 이제 사용하지 않아 머지하기 전에 삭제할 예정입니다. 
- 또한 `use-modal`이 사용하지 않게 됨에 따라 `경험 등록/보기`페이지에서 사용되었던 훅을 제거하고 `modalStore`의 메서드(open, reset)를 호출하여 사하도록 수정하였습니다. 
- 이제 실제 <Modal> 태그 렌더링은 최상단 `modal-provider.tsx`에서 전담합니다. 따라서 주로 사용되던 모달 템플릿인 `modal-basic` 컴포넌트 내부에 선언되어 있던 <Modal> 래퍼 태그는 제거하였습니다.


## 📸 Screenshot
<!-- 작업한 내용에 대한 스크린샷을 첨부해주세요. -->

## 🔔 ETC

- 동적인 변수(영어/한글) 뒤에 오는 조사를 구분하기 위한 `es-hangul` 패키지를 설치하였습니다 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 전역 모달 제공자와 중앙 모달 스토어를 도입하여 앱 전반에서 모달을 일관되게 관리합니다.
* **수정/개선**
  * 삭제 확인, 이탈 확인, 선택 후 로딩 등 기존 인라인 모달들이 중앙 모달 시스템으로 통합되어 동작이 표준화되고 코드 사용 방식이 단순화되었습니다.
* **변경**
  * 작업 설명 입력 필드의 최대 길이가 300자에서 500자로 늘어났습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->