### PR TITLE
[Fix] 경험 등록/수정/조회 페이지 리팩토링 전 버그 수정

### DIFF
--- a/src/features/experience-detail/config/messages.ts
+++ b/src/features/experience-detail/config/messages.ts
@@ -40,6 +40,7 @@ export const EXPERIENCE_MESSAGES = {
     SAVE_FAILED: "경험 저장에 실패했습니다. 다시 시도해주세요",
     DELETE_FAILED: "경험 삭제에 실패했습니다. 다시 시도해주세요",
     DEFAULT_SETTING_FAILED: "기본 경험 설정에 실패했습니다",
+    FETCH_FAILED: "경험 데이터를 불러오는데 실패했습니다.",
   },
 
   SUCCESS: {

--- a/src/features/experience-detail/model/use-actions.ts
+++ b/src/features/experience-detail/model/use-actions.ts
@@ -97,6 +97,9 @@ export const useExperienceSubmit = () => {
   });
 
   const submit = useCallback(async () => {
+    const { isSubmitting } = useExperienceDetailStore.getState();
+    if (isSubmitting) return;
+
     const result = validateExperienceDraft(draft);
 
     if (!result.ok) {

--- a/src/features/experience-detail/ui/experience-form/experience-form.tsx
+++ b/src/features/experience-detail/ui/experience-form/experience-form.tsx
@@ -9,6 +9,7 @@ import {
   useExperienceHeaderActions,
 } from "../../model/use-actions";
 import { useExperienceDateField } from "../../model/use-experience-date-field";
+import { useExperienceDetailStore } from "../../store/experience.store";
 import {
   useExperienceActions,
   useExperienceDraft,
@@ -22,6 +23,7 @@ import type { TextfieldType } from "@/shared/ui/textfield/textfield";
 const ExperienceForm = () => {
   const draft = useExperienceDraft();
   const isDraftDefault = useIsDraftDefault();
+  const isSubmitting = useExperienceDetailStore((s) => s.isSubmitting);
   const { setDraftField } = useExperienceActions();
 
   const { onToggleDefault } = useExperienceHeaderActions();
@@ -36,7 +38,7 @@ const ExperienceForm = () => {
         isDefault={isDraftDefault}
         onToggle={onToggleDefault}
         rightSlot={
-          <Button variant="primary" size="small" onClick={submit}>
+          <Button variant="primary" size="small" onClick={submit} disabled={isSubmitting}>
             작성완료
           </Button>
         }

--- a/src/pages/experience-detail/experience-detail-page.tsx
+++ b/src/pages/experience-detail/experience-detail-page.tsx
@@ -10,6 +10,7 @@ import {
   useLeaveConfirm,
   useGetExperienceDetail,
   hydrateExperienceFromApi,
+  EXPERIENCE_MESSAGES,
 } from "@/features/experience-detail";
 import { ModalBasic } from "@/shared/ui/modal/modal-basic";
 
@@ -51,7 +52,7 @@ const ExperienceDetailPage = ({ mode }: ExperiencePageProps) => {
   }
 
   if (shouldFetch && isError) {
-    return <div>경험 데이터를 불러오는데 실패했습니다.</div>;
+    return <div>{EXPERIENCE_MESSAGES.API.FETCH_FAILED}</div>;
   }
 
   const content = (() => {

--- a/src/shared/api/config/query-key.ts
+++ b/src/shared/api/config/query-key.ts
@@ -6,7 +6,7 @@ export const universityQueryKey = {
 
 // 경험 관련 API (experience)
 export const experienceQueryKey = {
-  all: () => ["experiene"],
+  all: () => ["experience"],
   lists: () => [...experienceQueryKey.all(), "list"], // 모든 경험 리스트
   list: (type: string, page: number) => [
     ...experienceQueryKey.lists(),
@@ -27,7 +27,7 @@ export const meQueryKey = {
 export const aiReportsQueryKey = {
   all: () => ["aiReports"],
   list: (page: number, keyword?: string) => [
-    ...experienceQueryKey.all(),
+    ...aiReportsQueryKey.all(),
     page,
     keyword,
   ], // page, keyword에 따른 AI report 리스트


### PR DESCRIPTION
## ✏️ Summary
<!-- 관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->
- close #156 

- 경험 등록/수정/삭제 페이지 리팩토링 전에, 선행 버그 수정 작업을 진행했습니다.
- Query Key 오타 및 잘못된 Query Key 참조를 수정해 캐시 키가 의도한 도메인 기준으로 동작하도록 바로잡았습니다.
- 제출 중 중복 요청이 발생하지 않도록 더블 submit 방지 로직을 추가하고, 에러 메시지 하드코딩 문자열을 상수로 분리해 메시지 관리 일관성을 높였습니다.


## 📑 Tasks
<!-- 해당 PR에 수행한 작업을 작성해주세요. -->
### ✔️ Query Key 오타 및 잘못된 참조 수정
- `experienceQueryKey.all()`에서 `"experiene"`로 작성되어 있던 오타를 `"experience"`로 수정했습니다.
- `aiReportsQueryKey.list()`가 `experienceQueryKey.all()`을 참조하고 있던 문제를 `aiReportsQueryKey.all()` 참조로 수정했습니다.
- 같은 `query-key.ts` 파일 내에서 발견된 단순 버그들이라, 리팩토링 전에 먼저 바로잡아 이후 캐시 무효화 및 조회 흐름 기준선을 명확히 하고자 했습니다.

```ts
// before
all: () => ["experiene"]

// after
all: () => ["experience"]
```

```ts
// before
list: (page: number, keyword?: string) => [
  ...experienceQueryKey.all(),
  page,
  keyword,
]

// after
list: (page: number, keyword?: string) => [
  ...aiReportsQueryKey.all(),
  page,
  keyword,
]
```

---

### ✔️ 경험 등록/수정 시 더블 submit 방지
- `submit` 함수 진입 시점에 `isSubmitting` 상태를 즉시 확인하는 guard를 추가해, 제출 중 중복 호출이 발생하면 바로 return 하도록 처리했습니다.
- UI 레벨에서도 `작성완료` 버튼에 `disabled={isSubmitting}`을 적용해, 사용자가 제출 중 상태를 시각적으로 인지할 수 있도록 했습니다.
- 단순히 버튼만 비활성화하는 방식이 아니라, **로직 레벨 + UI 레벨**로 이중 방어하도록 구성했습니다.

```ts
const submit = useCallback(async () => {
  const { isSubmitting } = useExperienceDetailStore.getState();
  if (isSubmitting) return;

  // ...
}, []);
```

```ts
<Button
  variant="primary"
  size="small"
  onClick={submit}
  disabled={isSubmitting}
>
  작성완료
</Button>
```

---


### ✔️ 에러 메시지 매직 스트링 상수화
- `experience-detail-page.tsx`에 직접 하드코딩되어 있던 `"경험 데이터를 불러오는데 실패했습니다."` 문자열을 `EXPERIENCE_MESSAGES.API.FETCH_FAILED` 상수로 분리했습니다.
- 메시지 관리 위치를 `messages.ts`로 일원화해, 이후 문구 수정이나 에러 정책 확장 시 관리가 쉬운 구조로 정리했습니다.

```ts
API: {
  SAVE_FAILED: "경험 저장에 실패했습니다. 다시 시도해주세요",
  DELETE_FAILED: "경험 삭제에 실패했습니다. 다시 시도해주세요",
  DEFAULT_SETTING_FAILED: "기본 경험 설정에 실패했습니다",
  FETCH_FAILED: "경험 데이터를 불러오는데 실패했습니다.",
}
```

```ts
if (shouldFetch && isError) {
  return <div>{EXPERIENCE_MESSAGES.API.FETCH_FAILED}</div>;
}
```



## 👀 To Reviewer
<!-- 리뷰어에게 요청하는 내용을 작성해주세요. -->
- 이번 PR은 경험 등록/수정/조회 페이지 전반 리팩토링에 앞서, 버그 수정에 초점을 맞춘 작은 PR입니다 🥹 리팩토링이랑 pr을 같이 쓰자니 애매해서 너무 작은 수정이긴 하지만 .. pr을 분리했습니닷 ..
- 리뷰 시에는 Query Key 수정이 실제 조회/캐시 무효화 흐름에 문제 없는지, 더블 submit 방지 방식이 현재 UX 흐름과 잘 맞는지, 그리고 `messages.ts` 기반 메시지 관리 방향이 적절한지 위주로 봐주시면 감사하겠습니다!
- 이후 약 3주 동안 경험 등록/수정/조회 페이지에 대해 단계적으로 리팩토링을 진행할 계획이며, 현재는 아래와 같은 흐름을 고려하고 있습니다.

> #### 현재 고려 중인 리팩토링 흐름
> 1. **PR 1 - 버그 수정**
>    - Query Key 오타 수정
>    - 잘못된 Query Key 참조 수정
>    - 더블 submit 방지
>    - 에러 메시지 매직 스트링 상수화
> 
> 2. **PR 2 - 중복 코드 제거 및 모듈 구조 정리**
> 
> 현재 experience-detail feature 내부에는 동일한 로직이 **hook 버전과 순수 함수 버전으로 이중 구현**되어 있는 부분이 있으며,  
> 실제 사용되지 않는 hook도 함께 남아 있는 상태입니다.  
> 
> 또한 `index.ts` 배럴 파일에서 외부에서 사용되지 않는 내부 유틸과 로직까지 광범위하게 re-export되고 있어, feature의 public API 범위가 불필요하게 넓어지고 import 경로 판단이 모호해지는 문제가 있습니다.
> 
> 따라서 아래와 같은 작업 진행하고자 합니다.
> 
> - 실제 사용되지 않는 **미사용 hook 제거**
> - 동일 로직이 hook/순수 함수 두 형태로 존재하는 경우 **사용되는 구현만 남기고 정리**
> - hook이 아닌 파일에 붙어 있는 `use-` prefix 제거 및 파일명 정리
> - `index.ts` 배럴 파일에서 **외부에서 실제 사용하는 API만 export하도록 범위 축소**
> - shared util re-export 제거 등 **feature public API 정리**
> 
> `index.ts` export 정리는 **오늘 정기 회의를 통해 결정된 기준에 맞추어 public API 범위를 재정리할 예정입니다.**
> 
> 3. **PR 3 - API 타입 안전성 강화 및 Alert 시스템 정리**
> 
> 현재 일부 API 훅에서 응답 타입을 `as unknown as` 형태로 강제 캐스팅하고 있어, 실제 응답 구조와 타입 정의가 어긋나더라도 컴파일 단계에서 잡히지 않는 문제가 있는 것을 확인했습니다.
> 
> 또한 경험 페이지 전용 Alert helper 함수가 여러 개로 분산되어 있어 메시지만 다른 유사 함수들이 반복적으로 존재하는 상태입니다.
> 
> 따라서 아래와 같은 작업 진행하고자 합니다.
>
> - `as unknown as` 형태의 **unsafe 타입 캐스팅 제거**
> - API 응답을 명시적으로 변환하는 **매핑 함수(toEntity / toList 등) 도입**
> - `use-actions.ts` 내부에 있던 DTO 변환 로직을 **lib 계층으로 이동**
> - 여러 개로 흩어진 **Alert helper 함수를 메시지 key 기반의 공통 함수로 통합**
> 
> 4. **PR 4 - Zustand 스토어 구조 개선**
> 
> 현재 경험 페이지 스토어에는 다음과 같은 구조적 문제가 있습니다.
> 
> - `isSubmitting`, `isTransitioning` 같은 상태를 **스토어에서 수동으로 관리**
> - `isDraftDirty`가 항상 `initialDraft`와 비교되어 **edit 모드에서도 dirty로 판단되는 버그 존재**
> - defaultExperience 상태가 **불필요한 객체 래핑 구조**로 되어 있음
> 
> 따라서 아래와 같은 작업 진행하고자 합니다.
> 
> - `isSubmitting` 상태 제거 → React Query `mutation.isPending`으로 대체
> - `isTransitioning` 플래그 제거
> - `savedSnapshot` 상태를 도입하여 **edit 모드에서 저장된 값과 비교하도록 변경**
> - `isDraftDirty` 비교 로직을 **mode 기반 비교 방식으로 수정**
> - `defaultExperience` 구조를 `defaultExperienceId`로 단순화
> 
> 5. **PR 5 - 폼 검증 및 STAR 필드 config화**
> 
> 현재 경험 입력 폼에서는 STAR 필드(Situation, Task, Action, Result)가 각 컴포넌트에서 **수동으로 반복 작성**되어 있으며, 검증 로직 또한 별도의 상수와 분리된 형태로 관리되고 있는 상황입니다.
>
> 따라서 아래와 같은 작업 진행하고자 합니다.
> 
> - STAR 필드 정보를 하나의 **config (`STAR_FIELDS`)로 통합**
> - Form / Viewer / validation에서 해당 config를 공통으로 참조
> - STAR 필드 렌더링을 **하드코딩 → map 기반 데이터 렌더링 구조로 변경**
> - blur 시점 기반 **실시간 필드 검증 로직 추가**
> - 입력 길이를 표시하는 **글자 수 카운터 UI 추가**
> 
> 6. **PR 6 - DatePicker 최적화 및 컴포넌트 책임 분리**
> 
> 현재 ExperienceViewer와 ExperienceForm 컴포넌트에는 다음 문제가 있습니다.
> 
> - View 모드에서도 **DatePicker 컴포넌트를 disabled 상태로 렌더링**
> - Viewer/Form 내부에 **헤더 UI, 삭제 모달, 데이터 표시 로직이 혼합**
> - 단일 컴포넌트가 여러 책임을 동시에 담당
> 
> 따라서 아래와 같은 작업 진행하고자 합니다.
> 
> - 삭제 확인 모달을 **ExperienceDeleteModal 컴포넌트로 분리**
> - StickyHeader 기반 헤더 UI를
>   - `ExperienceViewHeader`
>   - `ExperienceFormHeader`
>   컴포넌트로 분리
> - Viewer/Form 컴포넌트는 **순수 UI 역할만 담당하도록 정리**
> 
> 7. **PR 7 - Skeleton / Error Boundary / 접근성 개선**
> 
> 현재 경험 페이지에는 다음과 같은 UX 문제가 남아 있습니다.
> 
> - API 로딩 중 **빈 화면 표시**
> - 에러 발생 시 **스타일 없는 텍스트만 표시**
> - 일부 입력 필드에 **label 및 aria 속성이 없는 접근성 문제**
> 
> 따라서 아래와 같은 작업을 진행할 예정입니다.
> 
> - 로딩 상태에서 표시할 **ExperienceSkeleton UI 추가**
> - 에러 상태를 처리하는 **ExperienceError 컴포넌트 추가**
> - 렌더링 오류를 처리하기 위한 **ErrorBoundary 도입**
> - 입력 필드에 `label`, `aria-invalid`, `aria-describedby` 등 **접근성 속성 보완**
> - 목록 UI에 `role="list"` / `role="listitem"` 등 **스크린리더 대응 속성 추가**
> 

- 위와 같이 대략적으로만 계획해본 경험 등록/수정/조회 페이지 리팩토링 순서가 적절한지, 혹은 더 먼저 정리해야 할 부분이 있는지 의견 부탁드립니다.
- 또한 현재 생각한 PR 분리 단위가 너무 잘게 쪼개진 편인지 / 적절한 수준인지에 대해서도 함께 의견 주시면 이후 작업 계획을 조정하는 데  도움이 될 것 같습니다 🙇🏻‍♀️

## 📸 Screenshot
<!-- 작업한 내용에 대한 스크린샷을 첨부해주세요. -->

## 🔔 ETC