### PR TITLE
[Refactor] pagination 상태 유지 개선(searchParams)

### DIFF
--- a/src/features/experience-detail/types/experience-detail.types.ts
+++ b/src/features/experience-detail/types/experience-detail.types.ts
@@ -7,7 +7,7 @@ export type ExperienceType = ExperienceTypeCode;
 export interface ExperienceUpsertBody {
   title: string;
 
-  type: ExperienceType | null;
+  type: string | null;
 
   startAt: string | null;
 

--- a/src/features/experience-detail/ui/experience-viewer/experience-viewer.tsx
+++ b/src/features/experience-detail/ui/experience-viewer/experience-viewer.tsx
@@ -1,4 +1,7 @@
-import { EXPERIENCE_TYPE } from "@/shared/config/experience";
+import {
+  EXPERIENCE_TYPE,
+  type ExperienceTypeCode,
+} from "@/shared/config/experience";
 import { parseYMD } from "@/shared/lib/format-date";
 import { ModalBasic, Tooltip } from "@/shared/ui";
 import { Button } from "@/shared/ui/button/button";
@@ -40,7 +43,10 @@ const ExperienceViewer = () => {
     );
   }
 
-  const typeLabel = current.type ? EXPERIENCE_TYPE[current.type] : "미지정";
+  const typeLabel =
+    current.type && current.type in EXPERIENCE_TYPE
+      ? EXPERIENCE_TYPE[current.type as ExperienceTypeCode]
+      : "미지정";
 
   return (
     <main className={s.page}>

--- a/src/features/experience/api/use-experience-list.query.ts
+++ b/src/features/experience/api/use-experience-list.query.ts
@@ -4,13 +4,12 @@ import { api } from "@/shared/api/axios-instance";
 import { experienceQueryKey } from "@/shared/api/config/query-key";
 
 import type { ExperienceList } from "../type/experience";
-import type { ExperienceTypeCode } from "@/shared/config";
 
 export const getExperienceList = async ({
   type,
   page,
 }: {
-  type?: ExperienceTypeCode | undefined;
+  type?: string;
   page: number;
 }) => {
   const response = await api.experiences.getSummaryExperienceList({
@@ -24,7 +23,7 @@ export const useGetExperienceList = ({
   type,
   page,
 }: {
-  type: ExperienceTypeCode | null;
+  type?: string | null;
   page: number;
 }) => {
   return useQuery({

--- a/src/pages/experience/experience-page.css.ts
+++ b/src/pages/experience/experience-page.css.ts
@@ -62,3 +62,26 @@ export const icon = style({
   width: "6.4rem",
   height: "6.4rem",
 });
+
+export const listContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "100%",
+  maxWidth: "106rem",
+  minHeight: "50rem",
+  margin: "4rem auto 0",
+});
+
+export const spinner = style({
+  width: "20rem",
+  aspectRatio: "1 / 1",
+  objectFit: "contain",
+});
+
+export const spinnerText = style({
+  marginTop: "0.2rem",
+  ...themeVars.fontStyles.hline_m_18,
+  color: themeVars.color.gray600,
+});

--- a/src/pages/experience/experience-page.tsx
+++ b/src/pages/experience/experience-page.tsx
@@ -9,18 +9,17 @@ import { ExperienceFilter } from "@/widgets";
 import * as styles from "./experience-page.css";
 import { ExperienceListContainer } from "./ui/experience-list-container";
 
-import type { ExperienceTypeCode } from "@/shared/config/experience";
-
 const ExperiencePage = () => {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+
   const currentPage = Number(searchParams.get("page")) || 1;
-  const type = searchParams.get("type");
+  const type = searchParams.get("type") || "";
 
   const [isExpTouched, setIsExpTouched] = useState(false);
-  const navigate = useNavigate();
 
   const { data } = useGetExperienceList({
-    type: type as ExperienceTypeCode | null,
+    type,
     page: currentPage,
   });
 

--- a/src/pages/experience/experience-page.tsx
+++ b/src/pages/experience/experience-page.tsx
@@ -107,7 +107,7 @@ const ExperiencePage = () => {
       {isLoading ? (
         <section className={styles.listContainer}>
           <img src={CAT_SPINNER} className={styles.spinner} alt="로딩중" />
-          <p className={styles.spinnerText}>기업 정보를 불러오고 있어요</p>
+          <p className={styles.spinnerText}>경험 목록을 불러오고 있어요</p>
         </section>
       ) : (
         <ExperienceListContainer data={data} onPageChange={handlePageChange} />

--- a/src/pages/experience/experience-page.tsx
+++ b/src/pages/experience/experience-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 
 import { ROUTES } from "@/app/routes/paths";
 import { useGetExperienceList } from "@/features/experience/api/use-experience-list.query";
@@ -12,21 +12,31 @@ import { ExperienceListContainer } from "./ui/experience-list-container";
 import type { ExperienceTypeCode } from "@/shared/config/experience";
 
 const ExperiencePage = () => {
-  const [filter, setFilter] = useState<ExperienceTypeCode | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = Number(searchParams.get("page")) || 1;
+  const type = searchParams.get("type");
 
   const [isExpTouched, setIsExpTouched] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
   const navigate = useNavigate();
 
   const { data } = useGetExperienceList({
-    type: filter,
+    type: type as ExperienceTypeCode | null,
     page: currentPage,
   });
 
-  const handleFilterChange = (value: ExperienceTypeCode | null) => {
+  const handleFilterChange = (value: string) => {
     setIsExpTouched(true);
-    setFilter(value);
-    setCurrentPage(1);
+    setSearchParams({
+      type: value,
+      page: "1",
+    });
+  };
+
+  const handlePageChange = (page: number) => {
+    setSearchParams({
+      type: type ?? "",
+      page: String(page),
+    });
   };
 
   return (
@@ -53,7 +63,7 @@ const ExperiencePage = () => {
           </button>
 
           <ExperienceFilter
-            value={filter}
+            value={type}
             onChange={handleFilterChange}
             isTouched={isExpTouched}
             hasTotal={true}
@@ -61,7 +71,7 @@ const ExperiencePage = () => {
         </div>
       </section>
 
-      <ExperienceListContainer data={data} onPageChange={setCurrentPage} />
+      <ExperienceListContainer data={data} onPageChange={handlePageChange} />
     </div>
   );
 };

--- a/src/pages/experience/experience-page.tsx
+++ b/src/pages/experience/experience-page.tsx
@@ -1,9 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 
 import { ROUTES } from "@/app/routes/paths";
 import { useGetExperienceList } from "@/features/experience/api/use-experience-list.query";
+import { CAT_SPINNER } from "@/shared/assets/gifs";
 import { IconExp } from "@/shared/assets/icons";
+import { EXPERIENCE_TYPE } from "@/shared/config/experience";
 import { ExperienceFilter } from "@/widgets";
 
 import * as styles from "./experience-page.css";
@@ -12,16 +14,25 @@ import { ExperienceListContainer } from "./ui/experience-list-container";
 const ExperiencePage = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-
-  const currentPage = Number(searchParams.get("page")) || 1;
-  const type = searchParams.get("type") || "";
-
   const [isExpTouched, setIsExpTouched] = useState(false);
 
-  const { data } = useGetExperienceList({
+  const pageParam = searchParams.get("page");
+  const typeParam = searchParams.get("type");
+
+  // url 파라미터 값(page, type) 유효성 검사
+  const isInvalidNumber =
+    pageParam !== null && (isNaN(Number(pageParam)) || Number(pageParam) < 1);
+  const currentPage = isInvalidNumber ? 1 : Number(pageParam) || 1;
+
+  const isValidType = typeParam && typeParam in EXPERIENCE_TYPE;
+  const type = isValidType ? typeParam : "";
+
+  const { data, isLoading } = useGetExperienceList({
     type,
     page: currentPage,
   });
+
+  const { totalPage = 1 } = data ?? {};
 
   const handleFilterChange = (value: string) => {
     setIsExpTouched(true);
@@ -37,6 +48,29 @@ const ExperiencePage = () => {
       page: String(page),
     });
   };
+
+  // 페이지 쿼리스트링 강제 교정
+  useEffect(() => {
+    const isExceeding = currentPage > totalPage && totalPage > 0;
+
+    // 페이지가 이상하거나 'type'에 정의되지 않은 유형(abc)이 들어온 경우 강제 교정
+    if (isInvalidNumber || isExceeding || (typeParam && !isValidType)) {
+      const newParams = new URLSearchParams(searchParams);
+
+      if (isInvalidNumber || isExceeding) newParams.set("page", "1");
+      if (typeParam && !isValidType) newParams.delete("type");
+
+      setSearchParams(newParams, { replace: true });
+    }
+  }, [
+    currentPage,
+    totalPage,
+    isInvalidNumber,
+    isValidType,
+    typeParam,
+    searchParams,
+    setSearchParams,
+  ]);
 
   return (
     <div className={styles.page}>
@@ -70,7 +104,14 @@ const ExperiencePage = () => {
         </div>
       </section>
 
-      <ExperienceListContainer data={data} onPageChange={handlePageChange} />
+      {isLoading ? (
+        <section className={styles.listContainer}>
+          <img src={CAT_SPINNER} className={styles.spinner} alt="로딩중" />
+          <p className={styles.spinnerText}>기업 정보를 불러오고 있어요</p>
+        </section>
+      ) : (
+        <ExperienceListContainer data={data} onPageChange={handlePageChange} />
+      )}
     </div>
   );
 };

--- a/src/pages/experience/experience-page.tsx
+++ b/src/pages/experience/experience-page.tsx
@@ -33,7 +33,7 @@ const ExperiencePage = () => {
 
   const handlePageChange = (page: number) => {
     setSearchParams({
-      type: type ?? "",
+      type,
       page: String(page),
     });
   };

--- a/src/pages/home/search-section/search-section.tsx
+++ b/src/pages/home/search-section/search-section.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { useGetCompanies } from "@/features/home";
 import { ScaleFilter, IndustryFilter } from "@/features/home/ui";
@@ -11,41 +12,65 @@ import * as styles from "./search-section.css";
 
 import type { IndustryCode, ScaleCode } from "@/shared/config";
 
-interface CompanySearchParamsType {
-  keyword?: string;
-  industry?: IndustryCode;
-  scale?: ScaleCode;
-  sort?: string;
-  page?: number;
-  isRecruited?: boolean;
-}
-
 const SearchSection = () => {
-  const [params, setParams] = useState<CompanySearchParamsType>({
-    page: 1,
-    isRecruited: true,
-  });
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const keyword = searchParams.get("keyword") || "";
+  const industry = (searchParams.get("industry") as IndustryCode) || undefined;
+  const scale = (searchParams.get("scale") as ScaleCode) || undefined;
+  const page = Number(searchParams.get("page")) || 1;
+  const isRecruited = searchParams.get("isRecruited") !== "false";
+
+  const params = {
+    keyword,
+    industry,
+    scale,
+    page,
+    isRecruited,
+  };
 
   const { data, isLoading, isPlaceholderData } = useGetCompanies(params);
   const content = data?.content || [];
   const hasResult = content.length > 0;
-  const [searchValue, setSearchValue] = useState("");
-  const currentPage = params.page ?? 1;
+
+  const [searchValue, setSearchValue] = useState(keyword);
 
   const [isScaleTouched, setIsScaleTouched] = useState(false);
   const [isIndustryTouched, setIsIndustryTouched] = useState(false);
 
-  const updateParams = (patch: Partial<CompanySearchParamsType>) => {
-    setParams((prev) => ({
-      ...prev,
-      ...patch,
-    }));
+  const updateSearchParams = (
+    patch: Record<string, string | number | boolean | undefined>
+  ) => {
+    const newParams = new URLSearchParams(searchParams);
+
+    Object.entries(patch).forEach(([key, value]) => {
+      if (value === undefined || value === "") {
+        newParams.delete(key);
+      } else {
+        newParams.set(key, String(value));
+      }
+    });
+
+    if (!patch.page) {
+      newParams.set("page", "1");
+    }
+
+    setSearchParams(newParams);
   };
 
   const handlePageChange = (newPage: number) => {
     if (isPlaceholderData) return;
-    updateParams({ page: newPage });
+    updateSearchParams({ page: newPage });
   };
+
+  const handleSearch = (newKeyword: string) => {
+    updateSearchParams({ keyword: newKeyword });
+  };
+
+  // 검색값 유지
+  useEffect(() => {
+    setSearchValue(keyword);
+  }, [keyword]);
 
   return (
     <>
@@ -68,7 +93,7 @@ const SearchSection = () => {
               placeholder="지원하고 싶은 기업을 검색해보세요"
               value={searchValue}
               onChange={setSearchValue}
-              onSearch={(keyword) => updateParams({ keyword, page: 1 })}
+              onSearch={handleSearch}
             />
           </div>
         </div>
@@ -78,20 +103,20 @@ const SearchSection = () => {
         <div className={styles.container}>
           <div className={styles.filterWrapper}>
             <IndustryFilter
-              value={params.industry ?? null}
+              value={industry ?? null}
               isTouched={isIndustryTouched}
-              onChange={(industry) => {
+              onChange={(newIndustry) => {
                 setIsIndustryTouched(true);
-                updateParams({ industry, page: 1 });
+                updateSearchParams({ industry: newIndustry });
               }}
             />
 
             <ScaleFilter
-              value={params.scale}
+              value={scale}
               isTouched={isScaleTouched}
-              onChange={(scale) => {
+              onChange={(newScale) => {
                 setIsScaleTouched(true);
-                updateParams({ scale, page: 1 });
+                updateSearchParams({ scale: newScale });
               }}
             />
 
@@ -100,9 +125,9 @@ const SearchSection = () => {
             </p>
 
             <Toggle
-              checked={params.isRecruited ?? true}
-              onCheckedChange={(isRecruited) =>
-                updateParams({ isRecruited, page: 1 })
+              checked={isRecruited}
+              onCheckedChange={(checked) =>
+                updateSearchParams({ isRecruited: checked })
               }
             />
           </div>
@@ -122,7 +147,7 @@ const SearchSection = () => {
                 ))}
               </div>
               <Pagination
-                currentPage={currentPage}
+                currentPage={page}
                 totalPage={data?.totalPage ?? 1}
                 onPageChange={handlePageChange}
               />

--- a/src/pages/home/search-section/search-section.tsx
+++ b/src/pages/home/search-section/search-section.tsx
@@ -15,28 +15,88 @@ import type { IndustryCode, ScaleCode } from "@/shared/config";
 const SearchSection = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
+  // URL 파라미터 추출
   const keyword = searchParams.get("keyword") || "";
-  const industry = (searchParams.get("industry") as IndustryCode) || undefined;
-  const scale = (searchParams.get("scale") as ScaleCode) || undefined;
-  const page = Number(searchParams.get("page")) || 1;
-  const isRecruited = searchParams.get("isRecruited") !== "false";
+  const pageParam = searchParams.get("page");
+  const industryParam = searchParams.get("industry");
+  const scaleParam = searchParams.get("scale");
+  const recruitedParam = searchParams.get("isRecruited");
+
+  // 유효성 검사(page, industry, scale, isRecruited)
+  const isInvalidPage =
+    pageParam !== null && (isNaN(Number(pageParam)) || Number(pageParam) < 1);
+  const currentPage = isInvalidPage ? 1 : Number(pageParam) || 1;
+
+  const isValidIndustry =
+    industryParam === null ||
+    ["IT_SERVICE", "COMMERCE", "FINANCE", "CONSUMER_GOODS"].includes(
+      industryParam
+    );
+  const industry = isValidIndustry
+    ? (industryParam as IndustryCode)
+    : undefined;
+
+  const isValidScale =
+    scaleParam === null ||
+    ["STARTUP", "SMALL", "MID_LARGE", "LARGE"].includes(scaleParam);
+  const scale = isValidScale ? (scaleParam as ScaleCode) : undefined;
+
+  const isRecruited = recruitedParam !== "false";
 
   const params = {
     keyword,
     industry,
     scale,
-    page,
+    page: currentPage,
     isRecruited,
   };
 
   const { data, isLoading, isPlaceholderData } = useGetCompanies(params);
   const content = data?.content || [];
   const hasResult = content.length > 0;
+  const totalPage = data?.totalPage ?? 1;
 
   const [searchValue, setSearchValue] = useState(keyword);
-
   const [isScaleTouched, setIsScaleTouched] = useState(false);
   const [isIndustryTouched, setIsIndustryTouched] = useState(false);
+
+  // URL 강제 교정
+  useEffect(() => {
+    if (isLoading) return;
+
+    const isExceedingPage = currentPage > totalPage && totalPage > 0;
+    const isInvalidRecruited =
+      recruitedParam !== null &&
+      recruitedParam !== "true" &&
+      recruitedParam !== "false";
+
+    if (
+      isInvalidPage ||
+      isExceedingPage ||
+      !isValidIndustry ||
+      !isValidScale ||
+      isInvalidRecruited
+    ) {
+      const newParams = new URLSearchParams(searchParams);
+
+      if (isInvalidPage || isExceedingPage) newParams.set("page", "1");
+      if (!isValidIndustry) newParams.delete("industry");
+      if (!isValidScale) newParams.delete("scale");
+      if (isInvalidRecruited) newParams.set("isRecruited", "true");
+
+      setSearchParams(newParams, { replace: true });
+    }
+  }, [
+    currentPage,
+    totalPage,
+    isInvalidPage,
+    isValidIndustry,
+    isValidScale,
+    recruitedParam,
+    isLoading,
+    searchParams,
+    setSearchParams,
+  ]);
 
   const updateSearchParams = (
     patch: Record<string, string | number | boolean | undefined>
@@ -51,7 +111,7 @@ const SearchSection = () => {
       }
     });
 
-    if (!patch.page) {
+    if (!("page" in patch)) {
       newParams.set("page", "1");
     }
 
@@ -67,7 +127,6 @@ const SearchSection = () => {
     updateSearchParams({ keyword: newKeyword });
   };
 
-  // 검색값 유지
   useEffect(() => {
     setSearchValue(keyword);
   }, [keyword]);
@@ -135,20 +194,28 @@ const SearchSection = () => {
           {isLoading || hasResult ? (
             <>
               <div className={styles.companyGridStyle}>
-                {content.map(({ id, name, industry, scale, logo }) => (
-                  <CompanyCard
-                    key={id}
-                    id={id}
-                    companyName={name}
-                    industry={industry as IndustryCode}
-                    scale={scale as ScaleCode}
-                    logoUrl={logo}
-                  />
-                ))}
+                {content.map(
+                  ({
+                    id,
+                    name,
+                    industry: itemIndustry,
+                    scale: itemScale,
+                    logo,
+                  }) => (
+                    <CompanyCard
+                      key={id}
+                      id={id}
+                      companyName={name}
+                      industry={itemIndustry as IndustryCode}
+                      scale={itemScale as ScaleCode}
+                      logoUrl={logo}
+                    />
+                  )
+                )}
               </div>
               <Pagination
-                currentPage={page}
-                totalPage={data?.totalPage ?? 1}
+                currentPage={currentPage}
+                totalPage={totalPage}
                 onPageChange={handlePageChange}
               />
             </>

--- a/src/pages/matching-list/matching-list-page.tsx
+++ b/src/pages/matching-list/matching-list-page.tsx
@@ -42,6 +42,7 @@ const MatchingListPage = () => {
     setSearchValue(keyword);
   };
 
+  // 검색값 유지
   useEffect(() => {
     setSearchValue(keyword);
   }, [keyword]);

--- a/src/pages/matching-list/matching-list-page.tsx
+++ b/src/pages/matching-list/matching-list-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { useGetAiReportList } from "@/features/matching-list/api/use-get-matching-list";
 import { ICON_MATCH, ERROR } from "@/shared/assets/images";
@@ -7,38 +8,43 @@ import { Search } from "@/shared/ui";
 import { ListSection } from "./list-section/list-section";
 import * as styles from "./matching-list-page.css";
 
-interface MatchingListParams {
-  keyword?: string;
-  page: number;
-}
 const MatchingListPage = () => {
-  const [params, setParams] = useState<MatchingListParams>({
-    keyword: "",
-    page: 1,
-  });
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = Number(searchParams.get("page")) || 1;
+  const keyword = searchParams.get("keyword") || "";
 
-  const { data, isLoading } = useGetAiReportList(params);
-  const { content = [], currentPage = 1, totalPage = 1 } = data ?? {};
+  const { data, isLoading } = useGetAiReportList({
+    page: currentPage,
+    keyword,
+  });
+  const { content = [], totalPage = 1 } = data ?? {};
 
   const showEmptyState = !isLoading && content.length === 0;
   const showList = content.length > 0;
 
-  const [searchValue, setSearchValue] = useState("");
+  const [searchValue, setSearchValue] = useState(keyword);
 
-  const handleSearch = (keyword: string) => {
-    setParams({ keyword, page: 1 });
+  const handleSearch = (newKeyword: string) => {
+    setSearchParams({
+      keyword: newKeyword,
+      page: "1",
+    });
   };
 
   const handlePageChange = (page: number) => {
-    setParams((prev) => ({
-      ...prev,
-      page,
-    }));
+    setSearchParams({
+      keyword,
+      page: String(page),
+    });
   };
 
   const handleSearchChange = (keyword: string) => {
     setSearchValue(keyword);
   };
+
+  useEffect(() => {
+    setSearchValue(keyword);
+  }, [keyword]);
 
   return (
     <main className={styles.container}>
@@ -84,7 +90,7 @@ const MatchingListPage = () => {
           />
           <p className={styles.emptyTitle}>"검색 결과가 없습니다"</p>
           <p className={styles.emptyDescription}>
-            {params.keyword
+            {keyword
               ? "다른 검색어로 다시 시도해보세요."
               : "경험 등록하기 버튼을 눌러 경험을 등록해보세요."}
           </p>

--- a/src/pages/matching-list/matching-list-page.tsx
+++ b/src/pages/matching-list/matching-list-page.tsx
@@ -10,19 +10,48 @@ import * as styles from "./matching-list-page.css";
 
 const MatchingListPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const currentPage = Number(searchParams.get("page")) || 1;
+
+  // 1URL 파라미터 추출
+  const pageParam = searchParams.get("page");
   const keyword = searchParams.get("keyword") || "";
+
+  // 유효성 검사
+  const isInvalidPage =
+    pageParam !== null && (isNaN(Number(pageParam)) || Number(pageParam) < 1);
+  const currentPage = isInvalidPage ? 1 : Number(pageParam) || 1;
 
   const { data, isLoading } = useGetAiReportList({
     page: currentPage,
     keyword,
   });
+
   const { content = [], totalPage = 1 } = data ?? {};
 
   const showEmptyState = !isLoading && content.length === 0;
   const showList = content.length > 0;
 
   const [searchValue, setSearchValue] = useState(keyword);
+
+  // URL 강제 교정
+  useEffect(() => {
+    if (isLoading) return;
+
+    const isExceedingPage = currentPage > totalPage && totalPage > 0;
+
+    if (isInvalidPage || isExceedingPage) {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set("page", "1");
+
+      setSearchParams(newParams, { replace: true });
+    }
+  }, [
+    currentPage,
+    totalPage,
+    isInvalidPage,
+    isLoading,
+    searchParams,
+    setSearchParams,
+  ]);
 
   const handleSearch = (newKeyword: string) => {
     setSearchParams({
@@ -42,14 +71,12 @@ const MatchingListPage = () => {
     setSearchValue(keyword);
   };
 
-  // 검색값 유지
   useEffect(() => {
     setSearchValue(keyword);
   }, [keyword]);
 
   return (
     <main className={styles.container}>
-      {/* header 섹션 */}
       <div className={styles.headerWrapper}>
         <div className={styles.headerLeft}>
           <img
@@ -74,7 +101,7 @@ const MatchingListPage = () => {
           onSearch={handleSearch}
         />
       </div>
-      {/* 매칭 아이템 리스트 섹션 */}
+
       {showList ? (
         <ListSection
           matchingList={content}

--- a/src/shared/api/generate/http-client.ts
+++ b/src/shared/api/generate/http-client.ts
@@ -143,7 +143,7 @@ export interface ExperienceRequestDto {
    */
   title: string;
   /** @example "INTERNSHIP" */
-  type: "INTERNSHIP" | "PROJECT" | "EDUCATION" | "ETC";
+  type: string;
   /**
    * @format date
    * @example "2025-12-23"

--- a/src/shared/api/generate/http-client.ts
+++ b/src/shared/api/generate/http-client.ts
@@ -812,7 +812,7 @@ export class Api<
      */
     getSummaryExperienceList: (
       query?: {
-        type?: "INTERNSHIP" | "PROJECT" | "EDUCATION" | "ETC";
+        type?: string;
         /**
          * @format int32
          * @default 1

--- a/src/widgets/experience-filter/experience-filter.tsx
+++ b/src/widgets/experience-filter/experience-filter.tsx
@@ -1,16 +1,13 @@
 import { EXPERIENCE_TYPE } from "@/shared/config/experience";
 import { Dropdown } from "@/shared/ui";
 
-import {
-  EXPERIENCE_FILTER_OPTIONS,
-  type ExperienceFilterCode,
-} from "./filter-experience-constant";
+import { EXPERIENCE_FILTER_OPTIONS } from "./filter-experience-constant";
 
 import type { ExperienceTypeCode } from "@/shared/config/experience";
 
 interface ExperienceFilterProps {
-  value: ExperienceTypeCode | null;
-  onChange: (value: ExperienceTypeCode | null) => void;
+  value: string | null;
+  onChange: (value: string) => void;
   isTouched?: boolean;
   hasTotal?: boolean;
 }
@@ -22,7 +19,7 @@ const ExperienceFilter = ({
   hasTotal = true,
 }: ExperienceFilterProps) => {
   let triggerLabel = "경험 유형";
-  if (value) triggerLabel = EXPERIENCE_TYPE[value];
+  if (value) triggerLabel = EXPERIENCE_TYPE[value as ExperienceTypeCode];
   else if (isTouched && hasTotal) triggerLabel = "전체";
 
   const options = hasTotal
@@ -37,7 +34,7 @@ const ExperienceFilter = ({
         {options.map((option) => (
           <Dropdown.Item
             key={option.id}
-            onClick={() => onChange(option.code as ExperienceFilterCode | null)}
+            onClick={() => onChange(option.code ?? "")}
           >
             {option.label}
           </Dropdown.Item>


### PR DESCRIPTION
## ✏️ Summary
<!-- 관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->
- close #152 


## 📑 Tasks
<!-- 해당 PR에 수행한 작업을 작성해주세요. -->
페이지네이션의 상태가 유지되도록 리팩토링을 진행했습니다. 상세 페이지에서 '뒤로가기' 버튼을 통해 목록 페이지로 넘어왔을 때 이전 상태를 유지하려면 url에 목록에 관련된 정보들을 저장해야 하는데요, 이 때 페이지와 필터, 검색어 등 상태가 유지되어야 하는 정보들을 쿼리 파라미터로 넘겨 페이지를 옮겨다니더라도 상태가 유지되도록 구현해주었습니다.


```
// matching-list-page.tsx
const [searchParams, setSearchParams] = useSearchParams();
const currentPage = Number(searchParams.get("page")) || 1;
const keyword = searchParams.get("keyword") || "";
```


구현 방식은 위와 같습니다. 페이지 렌더링 시 `searchParams`를 통해 쿼리 파라미터의 값을 가져오고, 존재하지 않을 경우 디폴트 값으로 설정되도록 수정해주었습니다. 추가적으로 인라인 함수로 구현되어 있던 부분도 컨벤션에 맞게 '`handle-`' 형태의 함수로 분리해주었습니다. 

현재 페이지네이션이 사용되는 페이지는 홈, 경험 목록, 매칭 경험 목록 이렇게 3가지인데요, 이중 홈과 매칭 경험 목록의 경우 검색 기능이 포함되어 있는데 검색값이 날아가는 것을 방지하기 위해 useEffect를 통해 검색값이 유지되도록 해주었습니다~

```jsx
  // 검색값 유지
  useEffect(() => {
    setSearchValue(keyword);
  }, [keyword]);
```



## 👀 To Reviewer
<!-- 리뷰어에게 요청하는 내용을 작성해주세요. -->
리팩토링 과정에서 ExperienceFilter 컴포넌트의 value의 type을 `string | null`로 확장해주었습니다. 그 이유는 .. 제가 안정성을 위해 범위를 너무 좁혀놨더니 오히려 결합도가 지나치게 올라가서 하나 수정하려고 130913개의 파일을 건너야 하는 불상사가 발생하여서 리팩토링 하는 김에 같이 바꿔주었습니다! 

이 부분 수정하면서 http-client의 getRequestDto와, ExperienceRequestDto의 `type`과 getSummaryExperienceList 메소드의 `type`의 타입을 string으로 수정해주었습니다. 또한 유진이가 작업한 파일에서 

* src/features/experience-detail/types/experience-detail.types.ts의 type의 타입
* src/features/experience/api/use-experience-list.query.ts의 type의 타입
이렇게 수정되었습니다! 타입이랑, label의 기본값 정도만 수정되어서 큰 문제는 없겠지만 그래도 알아두어야 할 거 같아 전달합니다 ~ 


## 📸 Screenshot
<!-- 작업한 내용에 대한 스크린샷을 첨부해주세요. -->
추추의 작업 이슈로 화면녹화를 못하네요 쩝 .. 테스트 직접 해보기 ~~~~ >_<

## 🔔 ETC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 경험 상세 뷰의 타입 표시 로직을 강화해 누락된 유형은 "미지정"으로 안전하게 표시

* **리팩토링**
  * 경험 목록, 경험 필터, 검색, 매칭 리스트, 홈 검색의 필터·페이지네이션 상태를 URL 검색 파라미터로 전환해 공유·북마크·뒤로가기 동작 개선
  * 일부 컴포넌트의 내부 타입·파라미터 처리를 문자열 기반으로 정리

* **새 기능**
  * 목록 로딩 시 중앙 스피너 표시 및 관련 스타일 추가

* **변경**
  * 경험 타입 관련 입력과 API/컴포넌트 인터페이스가 문자열 기반으로 통일됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->